### PR TITLE
Fixed mobile styling

### DIFF
--- a/style.css
+++ b/style.css
@@ -8,11 +8,10 @@ body {
     color: white;
     font-family: 'Montserrat', sans-serif;
     text-align: center;
-    height: 100%;
+    height: 70%;
     display: flex;
     justify-content: center;
     flex-direction: column;
-    margin-top: -10rem;
 }
 
 h1{


### PR DESCRIPTION
The VW logo was moved negative depending on the font size. I changed it to use only 70% of the screen height.